### PR TITLE
New props for change the default lock icon color

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ React UX Password Field will work fine with its defaults, but there is a lot
 of configuration options.
 
 Read them on the site: [https://seethroughtrees.github.io/react-ux-password-field/](https://seethroughtrees.github.io/react-ux-password-field/)
+
+## Contributing
+
+Pull requests are happily welcomed, please [https://github.com/seethroughtrees/react-ux-password-field/issues](create an issue) explaining the problem you're solving first, and pull-request to an upstream branch instead of master.


### PR DESCRIPTION
lockIconLight={true}
will change the default color gray dark to gray light for the lock icon.
Necessary for inputs in darkness backgrounds.
![demo](https://cloud.githubusercontent.com/assets/3930607/15187664/2fccbc8c-17a2-11e6-9009-b621a2a020f6.png)
